### PR TITLE
Expose pan gesture recognizer subclass.

### DIFF
--- a/Sources/NYT360CameraController.h
+++ b/Sources/NYT360CameraController.h
@@ -13,6 +13,8 @@
 #import "NYT360DataTypes.h"
 #import "NYT360MotionManagement.h"
 
+@class NYT360CameraPanGestureRecognizer;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface NYT360CameraController : NSObject <UIGestureRecognizerDelegate>
@@ -42,22 +44,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)startMotionUpdates;
 - (void)stopMotionUpdates;
 
-#pragma mark - Camera Angle Updates
-
-- (void)updateCameraAngle;
-
-#pragma mark - Panning Options
+#pragma mark - Camera Control
 
 /**
- Changing this property will allow you to suppress undesired range of motion
- along either the x or y axis. For example, y axis input should be suppressed
- when a 360 video is playing inline in a scroll view.
+ *  Updates the camera angle based on the current device motion. It's assumed that this method will be called many times a second during SceneKit rendering updates.
+ */
+- (void)updateCameraAngle;
+
+/**
+ *  An otherwise vanilla subclass of UIPanGestureRecognizer used by NYT360Video to enable manual camera panning. This class is exposed so that host applications can more easily configure interaction with other gesture recognizers without having to have references to specific instances of an NYT360Video pan recognizer.
+ */
+@property (nonatomic, readonly) NYT360CameraPanGestureRecognizer *panRecognizer;
+
+/**
+ *  Changing this property will allow you to suppress undesired range of motion along either the x or y axis. For example, y axis input should be suppressed when a 360 video is playing inline in a scroll view.
  
- When this property is set, any disallowed axis will cause the current camera
- angles to be clamped to zero for that axis. Existing angles for the any allowed 
- axes will not be affected.
+ *  When this property is set, any disallowed axis will cause the current camera angles to be clamped to zero for that axis. Existing angles for the any allowed axes will not be affected.
  
- Defaults to NYT360PanningAxisHorizontal | NYT360PanningAxisVertical.
+ *  Defaults to NYT360PanningAxisHorizontal | NYT360PanningAxisVertical.
  */
 @property (nonatomic, assign) NYT360PanningAxis allowedPanningAxes;
 

--- a/Sources/NYT360CameraController.m
+++ b/Sources/NYT360CameraController.m
@@ -8,6 +8,7 @@
 
 #import "NYT360CameraController.h"
 #import "NYT360EulerAngleCalculations.h"
+#import "NYT360CameraPanGestureRecognizer.h"
 
 static const NSTimeInterval NYT360CameraControllerPreferredMotionUpdateInterval = (1.0 / 60.0);
 
@@ -18,7 +19,6 @@ static inline CGPoint subtractPoints(CGPoint a, CGPoint b) {
 @interface NYT360CameraController ()
 
 @property (nonatomic) SCNView *view;
-@property (nonatomic) UIGestureRecognizer *panRecognizer;
 @property (nonatomic) id<NYT360MotionManagement> motionManager;
 @property (nonatomic, strong, nullable) NYT360MotionManagementToken motionUpdateToken;
 @property (nonatomic) SCNNode *camera;
@@ -46,7 +46,7 @@ static inline CGPoint subtractPoints(CGPoint a, CGPoint b) {
         _currentPosition = CGPointMake(0, 0);
         _allowedPanningAxes = NYT360PanningAxisHorizontal | NYT360PanningAxisVertical;
         
-        _panRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
+        _panRecognizer = [[NYT360CameraPanGestureRecognizer alloc] initWithTarget:self action:@selector(handlePan:)];
         _panRecognizer.delegate = self;
         [_view addGestureRecognizer:_panRecognizer];
         

--- a/Sources/NYT360CameraPanGestureRecognizer.h
+++ b/Sources/NYT360CameraPanGestureRecognizer.h
@@ -1,0 +1,16 @@
+//
+//  NYT360CameraPanGestureRecognizer.h
+//  NYT360Video
+//
+//  Created by Jared Sinclair on 8/5/16.
+//  Copyright © 2016 The New York Times Company. All rights reserved.
+//
+
+@import UIKit;
+
+/**
+ *  An otherwise vanilla subclass of UIPanGestureRecognizer used by NYT360Video to enable manual camera panning. This class is exposed so that host applications can more easily configure interaction with other gesture recognizers without having to have references to specific instances of an NYT360Video pan recognizer.
+ */
+@interface NYT360CameraPanGestureRecognizer : UIPanGestureRecognizer
+
+@end

--- a/Sources/NYT360CameraPanGestureRecognizer.m
+++ b/Sources/NYT360CameraPanGestureRecognizer.m
@@ -1,0 +1,13 @@
+//
+//  NYT360CameraPanGestureRecognizer.m
+//  NYT360Video
+//
+//  Created by Jared Sinclair on 8/5/16.
+//  Copyright © 2016 The New York Times Company. All rights reserved.
+//
+
+#import "NYT360CameraPanGestureRecognizer.h"
+
+@implementation NYT360CameraPanGestureRecognizer
+
+@end

--- a/Sources/NYT360Video.h
+++ b/Sources/NYT360Video.h
@@ -20,3 +20,4 @@ FOUNDATION_EXPORT const unsigned char NYT360VideoVersionString[];
 #import <NYT360Video/NYT360DataTypes.h>
 #import <NYT360Video/NYT360MotionManagement.h>
 #import <NYT360Video/NYT360MotionManager.h>
+#import <NYT360Video/NYT360CameraPanGestureRecognizer.h>

--- a/Sources/NYT360ViewController.h
+++ b/Sources/NYT360ViewController.h
@@ -11,6 +11,9 @@
 @import AVFoundation;
 
 #import "NYT360MotionManagement.h"
+#import "NYT360DataTypes.h"
+
+@class NYT360CameraPanGestureRecognizer;
 
 CGRect NYT360ViewControllerSceneFrameForContainingBounds(CGRect containingBounds, CGSize underlyingSceneSize);
 CGRect NYT360ViewControllerSceneBoundsForScreenBounds(CGRect screenBounds);
@@ -27,6 +30,22 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)play;
 - (void)pause;
+
+#pragma mark - Camera Movement
+
+/**
+ *  An otherwise vanilla subclass of UIPanGestureRecognizer used by NYT360Video to enable manual camera panning. This class is exposed so that host applications can more easily configure interaction with other gesture recognizers without having to have references to specific instances of an NYT360Video pan recognizer.
+ */
+@property (nonatomic, readonly) NYT360CameraPanGestureRecognizer *panRecognizer;
+
+/**
+ *  Changing this property will allow you to suppress undesired range of motion along either the x or y axis. For example, y axis input should be suppressed when a 360 video is playing inline in a scroll view.
+ 
+ *  When this property is set, any disallowed axis will cause the current camera angles to be clamped to zero for that axis. Existing angles for the any allowed axes will not be affected.
+ 
+ *  Defaults to NYT360PanningAxisHorizontal | NYT360PanningAxisVertical.
+ */
+@property (nonatomic, assign) NYT360PanningAxis allowedPanningAxes;
 
 @end
 

--- a/Sources/NYT360ViewController.m
+++ b/Sources/NYT360ViewController.m
@@ -76,6 +76,20 @@ CGRect NYT360ViewControllerSceneBoundsForScreenBounds(CGRect screenBounds) {
     [self.playerScene pause];
 }
 
+#pragma mark - Camera Movement
+
+- (NYT360CameraPanGestureRecognizer *)panRecognizer {
+    return self.cameraController.panRecognizer;
+}
+
+- (NYT360PanningAxis)allowedPanningAxes {
+    return self.cameraController.allowedPanningAxes;
+}
+
+- (void)setAllowedPanningAxes:(NYT360PanningAxis)allowedPanningAxes {
+    self.cameraController.allowedPanningAxes = allowedPanningAxes;
+}
+
 #pragma mark - UIViewController
 
 - (void)viewDidLoad {

--- a/ios-360-videos.xcodeproj/project.pbxproj
+++ b/ios-360-videos.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		4736BC081D5394D200262306 /* NYT360MotionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4736BBFB1D53949900262306 /* NYT360MotionManagerTests.m */; };
 		4736BC091D5394D200262306 /* NYT360ViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4736BBFC1D53949900262306 /* NYT360ViewControllerTests.m */; };
 		4736BC0A1D5394D200262306 /* NYT360VideoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4736BBFD1D53949900262306 /* NYT360VideoTests.m */; };
+		47ACFE341D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 47ACFE321D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		47ACFE351D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.m in Sources */ = {isa = PBXBuildFile; fileRef = 47ACFE331D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.m */; };
 		47CD32371D539677000B3313 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4736BBE01D5393D800262306 /* main.m */; };
 		47DCD2A31D493E1400FBCD4B /* NYT360EulerAngleCalculations.h in Headers */ = {isa = PBXBuildFile; fileRef = 47DCD2A11D493E1400FBCD4B /* NYT360EulerAngleCalculations.h */; };
 		47DCD2A41D493E1400FBCD4B /* NYT360EulerAngleCalculations.m in Sources */ = {isa = PBXBuildFile; fileRef = 47DCD2A21D493E1400FBCD4B /* NYT360EulerAngleCalculations.m */; };
@@ -82,6 +84,8 @@
 		4736BBFB1D53949900262306 /* NYT360MotionManagerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NYT360MotionManagerTests.m; path = NYT360VideoTests/NYT360MotionManagerTests.m; sourceTree = SOURCE_ROOT; };
 		4736BBFC1D53949900262306 /* NYT360ViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NYT360ViewControllerTests.m; path = NYT360VideoTests/NYT360ViewControllerTests.m; sourceTree = SOURCE_ROOT; };
 		4736BBFD1D53949900262306 /* NYT360VideoTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NYT360VideoTests.m; path = NYT360VideoTests/NYT360VideoTests.m; sourceTree = SOURCE_ROOT; };
+		47ACFE321D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYT360CameraPanGestureRecognizer.h; sourceTree = "<group>"; };
+		47ACFE331D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYT360CameraPanGestureRecognizer.m; sourceTree = "<group>"; };
 		47DCD2A11D493E1400FBCD4B /* NYT360EulerAngleCalculations.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NYT360EulerAngleCalculations.h; sourceTree = "<group>"; };
 		47DCD2A21D493E1400FBCD4B /* NYT360EulerAngleCalculations.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NYT360EulerAngleCalculations.m; sourceTree = "<group>"; };
 		934A49491D46B0A1001AD295 /* NYT360Video.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NYT360Video.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -154,6 +158,8 @@
 				472324FC1D523F6000784F8F /* NYT360MotionManagement.h */,
 				472324FD1D5240DF00784F8F /* NYT360MotionManager.h */,
 				472324FE1D5240DF00784F8F /* NYT360MotionManager.m */,
+				47ACFE321D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.h */,
+				47ACFE331D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.m */,
 				934A49821D46B446001AD295 /* NYT360CameraController.h */,
 				934A49831D46B446001AD295 /* NYT360CameraController.m */,
 				47DCD2A11D493E1400FBCD4B /* NYT360EulerAngleCalculations.h */,
@@ -227,6 +233,7 @@
 				472325011D524AB600784F8F /* NYT360MotionManagement.h in Headers */,
 				470DB5DC1D4950FC001DD20C /* NYT360DataTypes.h in Headers */,
 				472324FF1D5240DF00784F8F /* NYT360MotionManager.h in Headers */,
+				47ACFE341D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.h in Headers */,
 				934A49881D46B446001AD295 /* NYT360CameraController.h in Headers */,
 				47DCD2A31D493E1400FBCD4B /* NYT360EulerAngleCalculations.h in Headers */,
 				934A498A1D46B446001AD295 /* NYT360PlayerScene.h in Headers */,
@@ -365,6 +372,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				934A498D1D46B446001AD295 /* NYT360ViewController.m in Sources */,
+				47ACFE351D54DFC70054F8D0 /* NYT360CameraPanGestureRecognizer.m in Sources */,
 				934A49891D46B446001AD295 /* NYT360CameraController.m in Sources */,
 				934A498B1D46B446001AD295 /* NYT360PlayerScene.m in Sources */,
 				47DCD2A41D493E1400FBCD4B /* NYT360EulerAngleCalculations.m in Sources */,


### PR DESCRIPTION
This changes changes `NYT360CameraController`'s pan recognizer ivar from a `UIPanGestureRecognizer` to `NYT360CameraPanGestureRecognizer`. The latter is an otherwise vanilla subclass of the former. It is exposed so that host applications can configure their other gesture recognizers to interact appropriately with the 360 pan recognizer. Using a subclass makes it possible to declare this logic without having to have references to specific instances of the pan recognizers. Without this change, inline playback might not be able to be panned manually depending on the host app configuration.
