### PR TITLE
Fix a bug that failed to clip the player scene to the containing bounds.

### DIFF
--- a/Sources/NYT360ViewController.m
+++ b/Sources/NYT360ViewController.m
@@ -102,6 +102,10 @@ CGRect NYT360ViewControllerSceneBoundsForScreenBounds(CGRect screenBounds) {
     self.view.backgroundColor = [UIColor blackColor];
     self.view.opaque = YES;
     
+    // Prevent the edges of the "aspect-fill" resized player scene from being
+    // visible beyond the bounds of `self.view`.
+    self.view.clipsToBounds = YES;
+    
     // self.sceneView.showsStatistics = YES;
     self.sceneView.autoresizingMask = UIViewAutoresizingNone;
     self.sceneView.backgroundColor = [UIColor blackColor];


### PR DESCRIPTION
This fixes a minor UI bug that failed to clip the 360 player scene contents to the bounds of the containing view controller's view.

This fixes https://jira.nyt.net/browse/MO-7067 and https://jira.nyt.net/browse/MO-7068.
