### PR TITLE
Setting the fitted dimensions to the player scene

### DIFF
--- a/Sources/NYT360PlayerScene.m
+++ b/Sources/NYT360PlayerScene.m
@@ -87,7 +87,9 @@
         [self.rootNode addChildNode:_cameraNode];
         
         SKScene *skScene = ({
-            SKScene *scene = [[SKScene alloc] initWithSize:CGSizeMake(1280, 1280)];
+			AVAssetTrack *assetTrack = [[player.currentItem.asset tracksWithMediaType:AVMediaTypeVideo] firstObject];
+			CGSize assetDimensions = assetTrack ? CGSizeApplyAffineTransform(assetTrack.naturalSize, assetTrack.preferredTransform) : CGSizeMake(1280, 1280);
+			SKScene *scene = [[SKScene alloc] initWithSize:CGSizeMake(fabsf(assetDimensions.width), fabsf(assetDimensions.height))];
             scene.shouldRasterize = YES;
             scene.scaleMode = SKSceneScaleModeAspectFit;
             _videoNode = ({


### PR DESCRIPTION
In order to set the accurate size to the SKScene, the scene is created using the information obtained from the AVAssetTrack of the player: the dimensions of the video and the specified transformation (which could be CGAffineTransformIdentity). As a transform is applied the values can be negative so the final size is using absolute values. 
Besides that, to prevent exceptionally failures, the previous hardcoded size (1280x1280) was kept.