### PR TITLE
SCNSceneRenderer's delegate isn't a zeroing weak property.

### DIFF
--- a/Sources/NYT360ViewController.m
+++ b/Sources/NYT360ViewController.m
@@ -78,6 +78,10 @@ CGRect NYT360ViewControllerSceneBoundsForScreenBounds(CGRect screenBounds) {
     return self;
 }
 
+- (void)dealloc {
+    _sceneView.delegate = nil;
+}
+
 #pragma mark - Playback
 
 - (void)play {


### PR DESCRIPTION
Nil this value out on dealloc to prevent a dangling pointer.

IOS-2012